### PR TITLE
Support snippet variables with parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # text-expander
 Text expander for work
+
+## Variable Placeholders
+
+Snippets can include dynamic values. Use either `{{name}}` or `(name)` in a snippet to mark a variable. When the snippet is triggered, a popup will ask for the value of each variable before inserting the text.

--- a/content.js
+++ b/content.js
@@ -414,7 +414,8 @@ function replaceTrigger(el) {
 }
 
 function hasVariables(text) {
-    return text.includes('{{') && text.includes('}}');
+    // Support both legacy {{var}} syntax and new (var) syntax
+    return /(\{\{[^}]+\}\}|\([^()]+\))/.test(text);
 }
 
 // Initialize

--- a/variables.js
+++ b/variables.js
@@ -2,7 +2,14 @@
 const urlParams = new URLSearchParams(window.location.search);
 const text = urlParams.get('text');
 const elementId = urlParams.get('elementId');
-const variables = [...new Set(text.match(/\{\{([^}]+)\}\}/g)?.map(v => v.slice(2, -2)) || [])];
+
+// Extract variables from either {{var}} or (var) syntax
+const variableRegex = /\{\{([^}]+)\}\}|\(([^()]+)\)/g;
+let match;
+const variables = new Set();
+while ((match = variableRegex.exec(text)) !== null) {
+    variables.add(match[1] || match[2]);
+}
 
 // Create input fields for each variable
 const form = document.getElementById('variableForm');
@@ -33,11 +40,12 @@ document.getElementById('submitBtn').addEventListener('click', () => {
     document.querySelectorAll('input').forEach(input => {
         values[input.dataset.variable] = input.value || input.dataset.variable;
     });
-    
-    // Replace variables in text
+
+    // Replace variables in text supporting both syntaxes
     let finalText = text;
     Object.entries(values).forEach(([variable, value]) => {
-        const regex = new RegExp(`\\{\\{${variable}\\}\\}`, 'g');
+        const escaped = variable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const regex = new RegExp(`\\{\\{${escaped}\\}\\}|\\(${escaped}\\)`, 'g');
         finalText = finalText.replace(regex, value);
     });
     
@@ -77,4 +85,4 @@ document.querySelectorAll('input').forEach(input => {
 // Handle cancel
 document.getElementById('cancelBtn').addEventListener('click', () => {
     window.close();
-}); 
+});


### PR DESCRIPTION
## Summary
- allow snippets to contain dynamic variables using `(name)` or legacy `{{name}}` syntax
- replace variables from either syntax in popup before inserting text
- document variable placeholder usage in README

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/text-expander/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6891fa086d9c8328b36d5cbbe17dd4aa