### PR TITLE
Support double-asterisk variable placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ standard text inputs and ServiceNow's special fields.
 
 ## Variable Placeholders
 
-Snippets can include dynamic values. Use either `{{name}}` or `(name)` in a
-snippet to mark a variable. When the snippet is triggered, a popup will prompt
-for the value of each variable before inserting the text.
+Snippets can include dynamic values. Use `**name**` in a snippet to mark a
+variable. The extension also supports the legacy `{{name}}` syntax. When the
+snippet is triggered, a popup will prompt for the value of each variable before
+inserting the text.
 
 

--- a/content.js
+++ b/content.js
@@ -398,8 +398,8 @@ function replaceTrigger(el) {
 }
 
 function hasVariables(text) {
-    // Support both legacy {{var}} syntax and new (var) syntax
-    return /(\{\{[^}]+\}\}|\([^()]+\))/.test(text);
+    // Support both legacy {{var}} syntax and new **var** syntax
+    return /(\{\{[^}]+\}\}|\*\*[^*]+\*\*)/.test(text);
 }
 
 // Initialize

--- a/variables.js
+++ b/variables.js
@@ -3,8 +3,8 @@ const urlParams = new URLSearchParams(window.location.search);
 const text = urlParams.get('text');
 const elementId = urlParams.get('elementId');
 
-// Extract variables from either {{var}} or (var) syntax
-const variableRegex = /\{\{([^}]+)\}\}|\(([^()]+)\)/g;
+// Extract variables from either {{var}} or **var** syntax
+const variableRegex = /\{\{([^}]+)\}\}|\*\*([^*]+)\*\*/g;
 let match;
 const variables = new Set();
 while ((match = variableRegex.exec(text)) !== null) {
@@ -45,7 +45,7 @@ document.getElementById('submitBtn').addEventListener('click', () => {
     let finalText = text;
     Object.entries(values).forEach(([variable, value]) => {
         const escaped = variable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const regex = new RegExp(`\\{\\{${escaped}\\}\\}|\\(${escaped}\\)`, 'g');
+        const regex = new RegExp(`\\{\\{${escaped}\\}\\}|\\*\\*${escaped}\\*\\*`, 'g');
         finalText = finalText.replace(regex, value);
     });
     


### PR DESCRIPTION
## Summary
- Allow the content script to detect `**variable**` placeholders in snippets
- Parse and replace `**variable**` tokens in the variable popup while retaining `{{variable}}` support
- Document the new `**name**` placeholder syntax in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689715b4cb808328b806872017e2ab1c